### PR TITLE
Issue #2

### DIFF
--- a/src/lazy/assign.zig
+++ b/src/lazy/assign.zig
@@ -41,10 +41,7 @@ test "assign" {
     const e = try assign(&graph, b, d);
     var session = try Session.init(allocator, &graph);
     defer session.deinit();
-    // TODO(Adam):
-    // Running assign op and variable should not error
-    // try session.run(&[_]Tensor{e, b});
-    const actual1 = try session.run(&[_]Tensor{e});
+    const actual1 = try session.run(&[_]Tensor{ e, b });
     const expected1 = try eager.constant(&arena.allocator, [_][2]f64{
         .{ 2, 3 },
         .{ 4, 5 },
@@ -55,5 +52,6 @@ test "assign" {
         .{ 5, 6 },
     });
     expectEqual(f64, actual1[0].f64, expected1);
+    expectEqual(f64, actual1[1].f64, expected1);
     // expectEqual(f64, actual2[0].f64, expected2);
 }

--- a/src/lazy/session.zig
+++ b/src/lazy/session.zig
@@ -264,8 +264,8 @@ fn runVariable(session: Session, cache: *Cache, index: usize, current_tensor: Te
 fn runAssign(session: Session, cache: *Cache, index: usize, current_tensor: Tensor) !void {
     const assign = session.graph.assigns.at(index);
     const value = try getValue(cache.*, assign.value);
-    // TODO(Adam): assignment should override variable with value
     try cache.putNoClobber(current_tensor, value);
+    _ = try cache.put(assign.variable, value);
 }
 
 // TODO(Adam): variables should persist between runs


### PR DESCRIPTION
Each tensor is only scheduled once in the execution order. This will speed up computations as well as preventing bugs such as when variables and assign operations are both scheduled.